### PR TITLE
Ability to disable clock to run Ember Acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ property: Ember.computed('clock.hour', function () {
   // this will update every hour
 })
 ```
+## Know Issues
+The clock service will break Ember acceptance tests, as it creates a continuous run loop to update the current time. To disable the runloop update your config/environment file with the following
+```js
+module.exports = function(environment) {
+  //...
+  if (environment === 'test') {
+    //...
+    ENV['ember-clock'] = {
+      disabled: true
+    }
+  }
+}
+```

--- a/addon/services/clock.js
+++ b/addon/services/clock.js
@@ -5,6 +5,7 @@ import { bool } from '@ember/object/computed';
 
 import { run } from '@ember/runloop';
 import Service from '@ember/service';
+import ENV from '../config/environment';
 
 /**
   ## ClockService
@@ -121,6 +122,9 @@ export default Service.extend({
   */
   tick() {
     this.setTime();
+    if(ENV['ember-clock'] && ENV['ember-clock'].disabled) {
+      return;
+    }
     this.set('nextTick', run.later(this, this.tick, 1000));
 	},
 

--- a/addon/services/clock.js
+++ b/addon/services/clock.js
@@ -5,7 +5,7 @@ import { bool } from '@ember/object/computed';
 
 import { run } from '@ember/runloop';
 import Service from '@ember/service';
-import ENV from '../config/environment';
+
 
 /**
   ## ClockService
@@ -122,7 +122,7 @@ export default Service.extend({
   */
   tick() {
     this.setTime();
-    if(ENV['ember-clock'] && ENV['ember-clock'].disabled) {
+    if(this.get('disabled')) {
       return;
     }
     this.set('nextTick', run.later(this, this.tick, 1000));

--- a/app/services/clock.js
+++ b/app/services/clock.js
@@ -1,1 +1,5 @@
-export { default } from 'ember-clock/services/clock';
+import ENV from '../config/environment';
+import Service from 'ember-clock/services/clock'
+export default Service.extend({
+  disabled: ENV['ember-clock'] && ENV['ember-clock'].disabled
+})

--- a/app/services/clock.js
+++ b/app/services/clock.js
@@ -1,5 +1,7 @@
 import ENV from '../config/environment';
 import Service from 'ember-clock/services/clock'
+
+const isDisabled = ENV['ember-clock'] && ENV['ember-clock'].disabled;
 export default Service.extend({
-  disabled: ENV['ember-clock'] && ENV['ember-clock'].disabled
+  disabled: isDisabled
 })


### PR DESCRIPTION
WIth new versions of ember it is discouraged to mock services. This changes allows a user to disable the updating of the clock service run loop while running acceptance tests.